### PR TITLE
TitaniumBlob -> TiContentFile

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 3.0.0
+version: 3.1.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: A native control for playing videos for Titanium. Based on Google ExoPlayer, using Titanium.Media.VideoPlayer API.
@@ -15,4 +15,4 @@ name: ti.exoplayer
 moduleid: ru.netris.mobile.exoplayer
 guid: 44228dfe-0521-4c68-b0fd-543b13f8c865
 platform: android
-minsdk: 9.0.0
+minsdk: 9.3.0

--- a/android/src/ru/netris/mobile/exoplayer/VideoPlayerProxy.java
+++ b/android/src/ru/netris/mobile/exoplayer/VideoPlayerProxy.java
@@ -19,7 +19,7 @@ import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiBaseActivity;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiLifecycle;
-import org.appcelerator.titanium.io.TitaniumBlob;
+import org.appcelerator.titanium.io.TiContentFile;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.view.TiUIView;
@@ -897,7 +897,7 @@ public class VideoPlayerProxy extends TiViewProxy implements TiLifecycle.OnLifec
 				mTiThumbnailRetriever.setUri(
 					Uri.parse(this.resolveUrl(null, TiConvert.toString(this.getProperty(TiC.PROPERTY_URL)))));
 			} else {
-				String path = url.contains(":") ? new TitaniumBlob(url).getNativePath() : resolveUrl(null, url);
+				String path = url.contains(":") ? new TiContentFile(url).nativePath() : resolveUrl(null, url);
 				Uri uri = Uri.parse(path);
 				mTiThumbnailRetriever.setUri(uri);
 			}


### PR DESCRIPTION
TitaniumBlob was renamed to TiContentFile (https://github.com/appcelerator/titanium_mobile/pull/12143)

So it builds again with 9.3.x
[ru.netris.mobile.exoplayer-android-3.1.0.zip](https://github.com/NetrisTV/ti.exoplayer/files/6089925/ru.netris.mobile.exoplayer-android-3.1.0.zip)

_not tested or updated any dependencies._ 